### PR TITLE
New fluentd version support v1.4.2

### DIFF
--- a/v1.4/Dockerfile
+++ b/v1.4/Dockerfile
@@ -1,0 +1,37 @@
+FROM fluent/fluentd:v1.4.2-debian-1.0
+MAINTAINER Baznai Cloud <info@banzaicloud.com>
+
+RUN mkdir -p /fluentd/etc /fluentd/plugins
+ONBUILD COPY plugins /fluentd/plugins/
+
+USER root
+
+RUN buildDeps="make gcc g++ libc-dev ruby-dev zlib1g-dev libz-dev git" \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends $buildDeps \
+  && gem install \
+        specific_install \
+        fluent-plugin-remote-syslog \
+        fluent-plugin-kubernetes_metadata_filter \
+        fluent-plugin-webhdfs \
+        fluent-plugin-elasticsearch \
+        fluent-plugin-prometheus \
+        fluent-plugin-s3 \
+        fluent-plugin-rewrite-tag-filter \
+        fluent-plugin-azurestorage \
+        fluent-plugin-oss
+RUN gem specific_install -l https://github.com/banzaicloud/fluent-plugin-gcs.git
+RUN gem sources --clear-all \
+  && apt-get purge -y --auto-remove \
+                  -o APT::AutoRemove::RecommendsImportant=false \
+                  $buildDeps \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+         /home/fluent/.gem/ruby/2.3.0/cache/*.gem \
+         /var/lib/gems/2.3.0/cache/*.gem \
+  && apt-get purge -y $buildDeps
+
+ADD fluent.conf /fluentd/etc/fluent.conf
+WORKDIR  /home/fluent/
+
+EXPOSE 24284

--- a/v1.4/fluent.conf
+++ b/v1.4/fluent.conf
@@ -1,0 +1,8 @@
+# This is the root config file, which only includes components of the actual configuration
+
+# Do not collect fluentd's own logs to avoid infinite loops.
+<match fluent.**>
+  @type null
+</match>
+
+@include /fluentd/etc/conf.d/*.conf


### PR DESCRIPTION
**Fluentd**
-  'fluentd' version '1.1.2' ->  'fluentd' version '1.4.2'

**Plugins**
- fluent-plugin-s3 1.1.7 -> 1.1.9
- fluent-plugin-rewrite-tag-filter 2.1.1 -> 2.2.0
- fluent-plugin-prometheus 1.2.1 -> 1.3.0
- fluent-plugin-oss 0.0.1 -> 0.0.2
- fluent-plugin-kubernetes_metadata_filter 2.1.5 -> 2.1.6
- fluent-plugin-elasticsearch 2.12.2 -> 3.4.1

**Base Image**

- fluent/fluentd:v1.4.2-debian-1.0